### PR TITLE
services/transfers/MaximumFlow: Implement Dinics Max-Flow Class

### DIFF
--- a/src/server/services/transfers/MaximumFlow/DinicsMaximumFlow.cpp
+++ b/src/server/services/transfers/MaximumFlow/DinicsMaximumFlow.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) CERN 2013-2015
+ *
+ * Copyright (c) Members of the EMI Collaboration. 2010-2013
+ *  See  http://www.eu-emi.eu/partners for details on the copyright
+ *  holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "DinicsMaximumFlow.h"
+
+DinicsMaximumFlow::Edge::Edge(int from, int to, long long capacity)
+        : from(from), to(to), residual(nullptr), flow(0), capacity(capacity) {}
+
+bool DinicsMaximumFlow::Edge::isResidual() {
+    return capacity == 0;
+}
+
+long long DinicsMaximumFlow::Edge::remainingCapacity() {
+    return capacity - flow;
+}
+
+void DinicsMaximumFlow::Edge::augment(long long bottleNeck) {
+    flow += bottleNeck;
+    residual->flow -= bottleNeck;
+}
+
+std::string DinicsMaximumFlow::Edge::edgeToString(int s, int t) {
+    std::string u = (from == s) ? "s" : ((from == t) ? "t" : std::to_string(from));
+    std::string v = (to == s) ? "s" : ((to == t) ? "t" : std::to_string(to));
+    return "Edge " + u + " -> " + v + " | flow = " + std::to_string(flow) +
+           " | capacity = " + std::to_string(capacity) + " | is residual: " + (isResidual() ? "true" : "false");
+}
+
+const long long DinicsMaximumFlow::MaximumFlowSolver::INF = LLONG_MAX / 2;
+
+DinicsMaximumFlow::MaximumFlowSolver::MaximumFlowSolver(int nodes, int source, int sink)
+        : nodes(nodes), source(source), sink(sink), solved(false), maximumFlow(0) {
+    initializeEmptyFlowGraph();
+}
+
+void DinicsMaximumFlow::MaximumFlowSolver::addEdge(int from, int to, long long capacity) {
+    if (capacity <= 0) {
+        throw std::invalid_argument("Forward edge capacity <= 0");
+    }
+    // From edge
+    Edge* e1 = new Edge(from, to, capacity);
+    // To Edge
+    Edge* e2 = new Edge(to, from, capacity);
+    e1->residual = e2;
+    e2->residual = e1;
+    graph[from].push_back(e1);
+    graph[to].push_back(e2);
+}
+
+std::vector<std::vector<DinicsMaximumFlow::Edge*>> DinicsMaximumFlow::MaximumFlowSolver::retrieveGraph() {
+    run();
+    return graph;
+}
+
+long long DinicsMaximumFlow::MaximumFlowSolver::retrieveMaximumFlow() {
+    run();
+    return maximumFlow;
+}
+
+void DinicsMaximumFlow::MaximumFlowSolver::initializeEmptyFlowGraph() {
+    graph = std::vector<std::vector<Edge*>>(nodes);
+}
+
+void DinicsMaximumFlow::MaximumFlowSolver::run() {
+    if (solved) return;
+    solve();
+    solved = true;
+}
+
+DinicsMaximumFlow::Dinics::Dinics(int nodes, int source, int sink)
+        : MaximumFlowSolver(nodes, source, sink) {
+    level = std::vector<int>(nodes);
+}
+
+void DinicsMaximumFlow::Dinics::solve() {
+    std::vector<int> next(nodes);
+    while (bfs()) {
+        std::fill(next.begin(), next.end(), 0);
+        while (true) {
+            long long flow = dfs(source, next, INF);
+            if (flow == 0) {
+                break;
+            }
+            maximumFlow += flow;
+        }
+    }
+}
+
+bool DinicsMaximumFlow::Dinics::bfs() {
+    std::fill(level.begin(), level.end(), -1);
+    std::queue<int> queue;
+    queue.push(source);
+    level[source] = 0;
+    while (!queue.empty()) {
+        int node = queue.front();
+        queue.pop();
+        for (Edge* edge : graph[node]) {
+            long long edgeCapacity = edge->remainingCapacity();
+            // Add node to next level of level graph if it has positive capacity, and it brings us closer to the sink
+            if (edgeCapacity > 0 && level[edge->to] == -1) {
+                level[edge->to] = level[node] + 1;
+                queue.push(edge->to);
+            }
+        }
+    }
+    return level[sink] != -1;
+}
+
+long long DinicsMaximumFlow::Dinics::dfs(int curr, std::vector<int>& next, long long flow) {
+    if (curr == sink) return flow;
+    int numEdges = graph[curr].size();
+    for (; next[curr] < numEdges; next[curr]++) {
+        Edge* edge = graph[curr][next[curr]];
+        long long edgeCapacity = edge->remainingCapacity();
+        if (edgeCapacity > 0 && level[edge->to] == level[curr] + 1) {
+            long long bottleNeck = dfs(edge->to, next, std::min(flow, edgeCapacity));
+            if (bottleNeck > 0) {
+                edge->augment(bottleNeck);
+                return bottleNeck;
+            }
+        }
+    }
+    // blocking flow found
+    return 0;
+}
+

--- a/src/server/services/transfers/MaximumFlow/DinicsMaximumFlow.h
+++ b/src/server/services/transfers/MaximumFlow/DinicsMaximumFlow.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) CERN 2013-2015
+ *
+ * Copyright (c) Members of the EMI Collaboration. 2010-2013
+ *  See  http://www.eu-emi.eu/partners for details on the copyright
+ *  holders.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FTS3_DINICSMAXIMUMFLOW_H
+#define FTS3_DINICSMAXIMUMFLOW_H
+
+#include <iostream>
+#include <vector>
+#include <queue>
+
+// DinicsMaximumFlow computes the maximum flow of a network in O(V^2E)
+class DinicsMaximumFlow {
+private:
+    struct Edge {
+        int from, to; // From and to capacities.
+        Edge *residual; // Each edge has a corresponding residual edge.
+        // TODO: Consider type for flows and capacities
+        long long flow; // f(e) initialized to 0.
+        const long long capacity; // c(e) initialized based upon resource constraints.
+
+        // Edge constructor
+        Edge(int from, int to, long long capacity);
+
+        //  isResidual returns true if the given edges capacity is 0 else false
+        bool isResidual();
+        long long remainingCapacity();
+        // Augments the flow of an edge as well as the flow of the reverse edge
+        void augment(long long bottleNeck);
+
+        // For debugging purposes. Prints the capacity and flow of an edge as well as if it is residual.
+        std::string edgeToString(int s, int t);
+    };
+
+    class MaximumFlowSolver {
+    public:
+        // TODO: Consider the initialization of infinity
+        // We initialize INF as LLONG_MAX / 2 to avoid overflow
+        static const long long INF;
+        int nodes, source, sink;
+        bool solved;
+        long long maximumFlow;
+        std::vector<std::vector<Edge*>> graph;
+
+        // Initializes MaximumFlowSolver with nodes, source, sink
+        MaximumFlowSolver(int nodes, int source, int sink);
+
+        // addEdge adds a forward and reverse edge to the graph. The forward edge is initialized with the specified capacity and the
+        void addEdge(int from, int to, long long capacity);
+        std::vector<std::vector<Edge*>> retrieveGraph();
+        long long retrieveMaximumFlow();
+
+    private:
+        // initializeEmptyFlowGraph creates an empty graph with n nodes
+        void initializeEmptyFlowGraph();
+        // run solves the graph
+        void run();
+        // computes maximum flow on the graph
+        virtual void solve() = 0;
+    };
+
+    class Dinics : public MaximumFlowSolver {
+    private:
+        std::vector<int> level;
+
+    public:
+        Dinics(int nodes, int source, int sink);
+
+    private:
+        void solve() override;
+        // bfs constructs the current level graph
+        bool bfs();
+        // dfs uses the level graph and invokes depth first search until a blocking flow is found
+        long long dfs(int curr, std::vector<int>& next, long long flow);
+    };
+};
+#endif //FTS3_DINICSMAXIMUMFLOW_H


### PR DESCRIPTION
Created a new directory in services/transfers introducing a class called `DinicsMaximumFlow` that provides the interface for creating a network graph as well as computing maximum flow. `DinicsMaximumFlow` iteratively utilizes breadth first search to compute level graphs and then depth first search to compute maximum flow until a blocking flow is found (no paths are found in the level graph via dfs).