### PR TITLE
fix: schema version mismatch in fts-schema-10.0.1.sql

### DIFF
--- a/src/db/schema/mysql/fts-schema-10.0.1.sql
+++ b/src/db/schema/mysql/fts-schema-10.0.1.sql
@@ -675,7 +675,7 @@ CREATE TABLE `t_schema_vers` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 INSERT INTO `t_schema_vers` (major, minor, patch, message)
-VALUES (10, 0, 0, 'Schema 10.0.0');
+VALUES (10, 0, 1, 'Schema 10.0.1');
 
 --
 -- Table structure for table `t_se`


### PR DESCRIPTION
The schema file `fts-schema-10.0.1.sql` installs the database structure
for version 10.0.1 but records the schema version as 10.0.0 in the
`t_schema_vers` table.

This PR updates `fts-schema-10.0.1.sql` to set the schema version in the
INSERT statement to 10.0.1 so that it correctly reflects the installed
schema.